### PR TITLE
Ignore C dependencies and offer more standard "npm test" script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cproject
 .project
 node_modules
+deps
 .lock-wscript
 build

--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
   "keywords": [ "hash", "md5", "sha", "crc", "whirlpool", "haval", "ripemd", "gost", "snefru", "alder", "tiger", "crc32", "crc32b", "sha256", "md4", "md2" ],
   "homepage" : "http://github.com/Sembiance/node-mhash",
   "licenses": [ { "type": "MIT", "url": "http://github.com/Sembiance/node-mhash/raw/master/LICENSE" } ],
-  "repository": { "type": "git", "url": "http://github.com/Sembiance/node-mhash.git" }
+  "repository": { "type": "git", "url": "http://github.com/Sembiance/node-mhash.git" },
+  "scripts": { "test": "node test.js" }
 }


### PR DESCRIPTION
I added `deps/` to `.gitignore` so that the C dependencies wouldn't accidentally get version controlled. I also added `npm test`, the Node convention for testing packages.
