### PR TITLE
node-waf is no more, now its node-gyp. Updated NAN version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Manual Installation
 ===================
 
 ```bash
-git clone "https://github.com/Sembiance/node-mhash.git"
-cd node-mhash
-node-waf configure build
+git clone "https://github.com/Sembiance/mhash.git"
+cd mhash
+node-gyp configure build
 ```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,43 @@
-{ "name": "mhash",
+{
+  "name": "mhash",
   "version": "2.1.3",
   "author": "Robert Schultz <robert@cosmicrealms.com>",
   "description": "Provides 27 hashing algorithms: md5, md4, md2, sha1, sha256, whirlpool, crc32, etc. MacOS X requires Xcode to be installed.",
   "main": "index",
-  "dependencies" : { "bindings" : "~1.2.1", "nan" : "~2.1.0" },
-  "engines": { "node": ">= 0.8.0" },
-  "keywords": [ "hash", "md5", "sha", "crc", "whirlpool", "haval", "ripemd", "gost", "snefru", "alder", "tiger", "crc32", "crc32b", "sha256", "md4", "md2" ],
-  "homepage" : "http://github.com/Sembiance/mhash",
-  "licenses": [ { "type": "MIT", "url": "http://github.com/Sembiance/mhash/raw/master/LICENSE" } ],
-  "repository": { "type": "git", "url": "http://github.com/Sembiance/mhash.git" }
+  "dependencies": {
+    "bindings": "~1.2.1",
+    "nan": "^2.3.5"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "keywords": [
+    "hash",
+    "md5",
+    "sha",
+    "crc",
+    "whirlpool",
+    "haval",
+    "ripemd",
+    "gost",
+    "snefru",
+    "alder",
+    "tiger",
+    "crc32",
+    "crc32b",
+    "sha256",
+    "md4",
+    "md2"
+  ],
+  "homepage": "http://github.com/Sembiance/mhash",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/Sembiance/mhash/raw/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/Sembiance/mhash.git"
+  }
 }


### PR DESCRIPTION
This fixes error building o debian (at least).

Also fixed repository path.