### PR TITLE
Apply patch to fix build on musl

### DIFF
--- a/deps/mhash/include/mutils/mutils.h
+++ b/deps/mhash/include/mutils/mutils.h
@@ -21,6 +21,12 @@
 #if !defined(__MUTILS_H)
 #define __MUTILS_H
 
+// Added to satisfy OS X
+#if !defined(_Bool)
+#define _Bool bool
+#endif
+// End custom addition
+
 #include <mutils/mincludes.h>
 
 #if defined(const)


### PR DESCRIPTION
Build on alpine failed with message:
```
make[1]: Leaving directory '/usr/lib/node_modules/mhash/deps/mhash'
  TOUCH Release/obj.target/libmhash.stamp
  CXX(target) Release/obj.target/mhash/mhash.o
In file included from ../deps/mhash/include/mutils/mtypes.h:24:0,
                 from ../deps/mhash/include/mhash.h:8,
                 from ../mhash.cc:7:
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' has not been declared
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mutils.h:250:70: note: in expansion of macro 'mutils_boolean'
 mutils_word32 *mutils_word32nswap(mutils_word32 *x, mutils_word32 n, mutils_boolean destructive);
                                                                      ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mutils.h:253:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mutils_thequals(mutils_word8 *text, mutils_word8 *hash, __const mutils_word32 len);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:73:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash(MHASH thread, const void *plaintext, mutils_word32 size);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:91:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash_hmac_deinit(MHASH thread, void *result);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:95:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash_save_state_mem(MHASH thread, void *mem, mutils_word32 *mem_size);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:116:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash_keygen_uses_salt(keygenid type);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:117:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash_keygen_uses_count(keygenid type);
 ^~~~~~~~~~~~~~
../deps/mhash/include/mutils/mutils.h:100:24: error: '_Bool' does not name a type
 #define mutils_boolean _Bool
                        ^
../deps/mhash/include/mutils/mhash.h:118:1: note: in expansion of macro 'mutils_boolean'
 mutils_boolean mhash_keygen_uses_hash_algorithm(keygenid type);
 ^~~~~~~~~~~~~~
../mhash.cc: In function 'char* hash(hashid, unsigned char*, long unsigned int)':
../mhash.cc:53:21: error: 'mhash' was not declared in this scope
  mhash(td, data, len);
                     ^
make: *** [mhash.target.mk:99: Release/obj.target/mhash/mhash.o] Error 1
make: Leaving directory '/usr/lib/node_modules/mhash/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Linux 4.9.31-moby
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /usr/lib/node_modules/mhash
gyp ERR! node -v v6.10.3
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok 
npm ERR! Linux 4.9.31-moby
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install" "-g" "mhash-master"
npm ERR! node v6.10.3
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
```

I found a patch for musl on [alpinelinux/aports](https://github.com/alpinelinux/aports/blob/master/testing/libmhash/musl-fix-bool-includes.patch) and applying it fixed my build on alpine